### PR TITLE
Hotfix 4.4.3: Projekte mit mehreren Posten lassen sich wieder speichern

### DIFF
--- a/app/Rules/ExactlyOneZeroMoneyRule.php
+++ b/app/Rules/ExactlyOneZeroMoneyRule.php
@@ -2,12 +2,24 @@
 
 namespace App\Rules;
 
+use App\Support\Money\MoneyInput;
+use Cknow\Money\Money;
 use Closure;
 use Illuminate\Contracts\Validation\DataAwareRule;
 use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 
+/**
+ * Validates that exactly one of two paired money fields (a Posten's Einnahme and
+ * Ausgabe) is zero — a Posten is either income or expense, never both or neither.
+ *
+ * $otherField is the sibling field's rule identifier and may contain `*` wildcard
+ * segments (e.g. `posts.*.einnahmen`). Each `*` is resolved against the corresponding
+ * segment of the concrete $attribute under validation (e.g. `posts.0.ausgaben`) to
+ * build the sibling's actual data path (`posts.0.einnahmen`), which is then looked
+ * up in the data captured via setData().
+ */
 class ExactlyOneZeroMoneyRule implements DataAwareRule, ValidationRule
 {
     private array $data = [];
@@ -16,27 +28,38 @@ class ExactlyOneZeroMoneyRule implements DataAwareRule, ValidationRule
         protected string $otherField,
     ) {}
 
-    public function setData(array $data): void
+    /**
+     * @return $this
+     */
+    public function setData(array $data): static
     {
         $this->data = $data;
+
+        return $this;
     }
 
     public function validate(string $attribute, mixed $value, Closure $fail): void
     {
         // pairs every attribute field with the other field, pair[0] has the actual field, pair[1] can have *'s
-        $otherAccessors = Str::of($attribute)->explode('.')
+        $otherPath = Str::of($attribute)->explode('.')
             ->zip(Str::of($this->otherField)->explode('.'))
-            ->map(fn (Collection $pair) => $pair[1] === '*' ? $pair[0] : $pair[1]);
-        // dump($otherAccessors);
-        $otherMoney = $this->data;
-        while (($idx = $otherAccessors->shift()) !== null) {
-            // dump($otherMoney, $idx, $otherAccessors);
-            $otherMoney = $otherMoney[$idx];
+            ->map(fn (Collection $pair) => $pair[1] === '*' ? $pair[0] : $pair[1])
+            ->implode('.');
+        $otherMoney = data_get($this->data, $otherPath);
+
+        // Both sides can arrive as the raw string of a money input (see MoneyInput). Only a value
+        // that is no money value at all (null, an array) is skipped; an unparsable string reads as
+        // 0 here, and either way the `money` rule on each of the two fields reports it.
+        $value = MoneyInput::parse($value);
+        $otherMoney = MoneyInput::parse($otherMoney);
+        if (! $value instanceof Money || ! $otherMoney instanceof Money) {
+            return;
         }
-        // dd($otherMoney);
-        $oneIsZero = (($value->getAmount() === '0') xor ($otherMoney->getAmount() === '0'));
-        // dd($value, $otherMoney, ($value->getAmount() === "0"),($otherMoney->getAmount() === "0"), $oneIsZero);
+
+        $oneIsZero = ($value->isZero() xor $otherMoney->isZero());
         if (! $oneIsZero) {
+            // :position is filled in by the validator from the attribute's row index (1-based),
+            // so the message can name the Posten without this rule computing anything.
             $fail(__('errors.one-money-has-to-be-zero'));
         }
     }

--- a/app/Rules/NonNegativeMoneyRule.php
+++ b/app/Rules/NonNegativeMoneyRule.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Rules;
+
+use App\Support\Money\MoneyInput;
+use Cknow\Money\Money;
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
+
+/**
+ * Rejects negative money amounts, e.g. a Posten's Einnahme/Ausgabe entered as
+ * "-50 €", which would otherwise silently flip the project's totals.
+ *
+ * Only a value that is no money value at all (null, an array) is skipped; an
+ * unparsable string reads as 0 and is reported by the `money` rule on the same
+ * field, so failing here as well would only add a second, redundant message.
+ *
+ * The message names the row via :position, which the validator fills in from the
+ * attribute — it therefore expects an array attribute (`posts.*.ausgaben`). Bind
+ * a per-field message in validation.php if the rule is ever used on a plain field.
+ */
+class NonNegativeMoneyRule implements ValidationRule
+{
+    public function validate(string $attribute, mixed $value, Closure $fail): void
+    {
+        $money = MoneyInput::parse($value);
+
+        if (! $money instanceof Money) {
+            return;
+        }
+
+        if ($money->isNegative()) {
+            $fail(__('errors.negative-money'));
+        }
+    }
+}

--- a/app/States/Project/ProjectState.php
+++ b/app/States/Project/ProjectState.php
@@ -9,6 +9,7 @@ use App\Models\User;
 use App\Rules\DescriptionLengthRule;
 use App\Rules\ExactlyOneZeroMoneyRule;
 use App\Rules\FluxEditorRule;
+use App\Rules\NonNegativeMoneyRule;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Validation\Rule;
 use Livewire\Wireable;
@@ -126,8 +127,8 @@ abstract class ProjectState extends State implements Wireable
             'posts' => 'required|array|min:1',
             'posts.*.id' => 'sometimes|integer',
             'posts.*.name' => 'required|string|max:128|min:1',
-            'posts.*.einnahmen' => 'required|money:EUR',
-            'posts.*.ausgaben' => ['required', 'money:EUR', new ExactlyOneZeroMoneyRule('posts.*.einnahmen')],
+            'posts.*.einnahmen' => ['required', 'money:EUR', new NonNegativeMoneyRule],
+            'posts.*.ausgaben' => ['required', 'money:EUR', new NonNegativeMoneyRule, new ExactlyOneZeroMoneyRule('posts.*.einnahmen')],
             'posts.*.position' => 'sometimes|integer',
             'posts.*.bemerkung' => 'sometimes|string|max:256',
         ];

--- a/app/Support/Money/MoneyInput.php
+++ b/app/Support/Money/MoneyInput.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Support\Money;
+
+use Cknow\Money\Money;
+
+/**
+ * Turns whatever a wire:model bound money input hands us back into a Money object.
+ *
+ * Usually MoneySynth does this during hydration, but a money value nested in a plain
+ * array (e.g. `posts.*.einnahmen`) loses its synth metadata whenever Livewire's JS
+ * diff consolidates the update into the parent array, and then the raw display string
+ * lands in the component. Anything that reads such a value has to be able to re-cast it.
+ */
+final class MoneyInput
+{
+    /**
+     * @return Money|null null when the value is not a money value at all (not a formatted string)
+     */
+    public static function parse(mixed $value): ?Money
+    {
+        if ($value instanceof Money) {
+            return $value;
+        }
+
+        if ($value instanceof \Money\Money) {
+            return Money::fromMoney($value);
+        }
+
+        if (is_string($value)) {
+            return Money::fromMoney((new DefaultMoneyFormater)->inverse($value));
+        }
+
+        return null;
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "openadministration/stufis",
     "type": "project",
     "description": "Webinterface für das Management und Digitalisierung von Finanzanträgen und deren Buchung für Studierendenschaften nach Deutschem Recht",
-    "version": "4.4.2",
+    "version": "4.4.3",
     "license": "AGPL",
     "require": {
         "php": "^8.4",

--- a/docs/feature-changelog.md
+++ b/docs/feature-changelog.md
@@ -1,3 +1,14 @@
+# v4.4.3
+* Projekte mit mehreren Posten ließen sich nicht mehr speichern, wenn vor dem Speichern in jeder Postenzeile etwas geändert wurde – das Speichern brach mit einer Fehlerseite ab. Die Beträge gingen dabei auf dem Weg zum Server verloren; sie werden nun wieder zuverlässig als Geldbeträge erkannt.
+* Fehlermeldungen beim Speichern eines Projekts erscheinen jetzt direkt an dem Feld, das sie ausgelöst hat – und zwar alle. Bisher wurde nur die erste Meldung als einzelne Zeile über dem Formular angezeigt, sodass unklar blieb, welche Zeile oder welches Feld gemeint war.
+* Posten, in denen sowohl eine Einnahme als auch eine Ausgabe stand (aus Altdaten), ließen sich nicht mehr korrigieren: Beide Betragsfelder waren gesperrt, während das Speichern genau diese Kombination bemängelte. Ein Betragsfeld ist jetzt nur noch gesperrt, solange es selbst leer ist.
+* Negative Beträge werden in Posten nicht mehr angenommen. Bisher konnte z. B. eine Ausgabe von "-50 €" gespeichert werden und hat die Projektsummen still verfälscht.
+* Die Meldungen zu den Beträgen eines Postens benennen nun einheitlich die betroffene Postenzeile und erklären die Regel: Ein Posten ist entweder eine Einnahme oder eine Ausgabe.
+* Posten lassen sich in der Projektbearbeitung per Ziehgriff in der Spalte "Nr." umsortieren. Die Reihenfolge wird gespeichert und bleibt in Ansicht und Ausdruck erhalten.
+* Wurde ein Projekt zwischenzeitlich von jemand anderem geändert, erscheint nun ein verständlicher Hinweis statt eines technischen Platzhaltertexts.
+
+---
+
 # v4.4.2
 * Projektbeschreibungen und Nachrichten werden nun mit der vollständigen Formatierung des Editors angezeigt (Aufzählungen, nummerierte Listen, Überschriften, Links, Fett-/Kursivschrift). Zuvor gingen z. B. Listen in der Ansicht verloren, obwohl sie korrekt gespeichert waren.
 * Ältere, noch als reiner Text gespeicherte Projektbeschreibungen behalten beim Anzeigen und erneuten Bearbeiten ihre Zeilenumbrüche und werden automatisch ins neue Format übernommen.

--- a/lang/de/errors.php
+++ b/lang/de/errors.php
@@ -22,7 +22,8 @@ return [
     'flux-editor-malicious-html' => 'Fehlerhafte HTML-Tags',
     'description-too-short' => 'Die Beschreibung muss mindestens :min Zeichen lang sein.',
     'description-too-long' => 'Die Beschreibung darf höchstens :max Zeichen lang sein.',
-    'one-money-has-to-be-zero' => 'Es darf nur Ausgabe oder Einnahme 0 sein',
+    'one-money-has-to-be-zero' => 'Posten :position ist entweder eine Einnahme oder eine Ausgabe – genau eines der beiden Felder muss 0 € betragen.',
+    'negative-money' => 'Der Betrag in Posten :position darf nicht negativ sein.',
     'attachment-contains-macros' => 'Anhänge dürfen keine Makros enthalten. Bitte entferne die Makros oder lade das Dokument ohne Makros (bzw. als PDF) hoch.',
     'attachment-content-mismatch' => 'Der Inhalt des Anhangs passt nicht zur angegebenen Dateiendung. Bitte lade eine gültige Datei im passenden Format hoch.',
 ];

--- a/lang/de/project.php
+++ b/lang/de/project.php
@@ -25,6 +25,8 @@ return [
     ],
     'error' => [
         'posten_illegal_deleted' => 'Posten mit denen noch eine Abrechnung existiert dürfen nicht gelöscht werden!',
+        'check-marked-fields' => 'Bitte korrigiere die markierten Felder.',
+        'version-mismatch' => 'Das Projekt wurde zwischenzeitlich von jemand anderem geändert. Bitte lade die Seite neu und übertrage deine Änderungen erneut.',
     ],
     'view' => [
         'source' => [
@@ -103,6 +105,7 @@ return [
             'subheading' => 'Budgetplanung mit Ausgabenverfolgung',
             'info_toggle' => 'Trage hier bitte deine geplanten Einnahmen und Ausgaben ein. Wichtig ist, dass du für jeden Punkt eine eigene Zeile (Projektposten) benutzt. Wie detailliert dieser Finanzplan sein muss, erfährst du von deinen Finanzverantwortlichen. Das ist notwendig, damit später jeder Projektposten in den richtigen Haushaltstitel einsortiert werden kann.',
             'nr' => 'Nr.',
+            'reorder' => 'Posten verschieben',
             'group' => 'Ein/Ausgabengruppe',
             'remark' => 'Bemerkung',
             'title' => 'Titel',

--- a/resources/views/components/money-input.blade.php
+++ b/resources/views/components/money-input.blade.php
@@ -2,9 +2,16 @@
     'disabled' => false,
 ])
 
+@php
+    // Both branches render the error: a disabled field can still carry one (a Posten holding
+    // an income *and* an expense disables both inputs), and hiding the reason leaves the user
+    // with a save that fails and nothing to act on.
+    $errorName = $attributes->thatStartWith('wire:model')->first();
+@endphp
+
 @if(!$disabled)
     <flux:input {{ $attributes->merge(['class:input' => 'text-right']) }} />
-    <flux:error :name="$attributes->thatStartWith('wire:model')->first()" />
 @else
     <flux:input disabled readonly variant="filled" {{ $attributes->merge(['class:input' => 'text-right text-black!']) }}/>
 @endif
+<flux:error :name="$errorName" />

--- a/resources/views/pages/project/⚡edit-project/edit-project.blade.php
+++ b/resources/views/pages/project/⚡edit-project/edit-project.blade.php
@@ -65,6 +65,7 @@
                             <flux:select.option value="{{ $rg->slug }}">{{ $rg->label }}</flux:select.option>
                         @endforeach
                     </flux:select>
+                    <flux:error name="recht" />
                     {{-- Dynamic Additional Fields per Rechtsgrundlage --}}
                     @if($recht)
                         @php $select_legal = $rechtsgrundlagen[$recht]; @endphp
@@ -73,6 +74,7 @@
                                 <flux:input wire:model="recht_additional"
                                         :label="$select_legal->label_additional"
                                         placeholder="{{ $select_legal->placeholder ?? '' }}"/>
+                                <flux:error name="recht_additional" />
                             @endif
                         </div>
                         <div class="sm:col-span-2">
@@ -105,6 +107,7 @@
                 {{-- Project Name --}}
                 <div class="">
                     <flux:input type="text" :label="__('project.view.details.name')" wire:model="name" />
+                    <flux:error name="name" />
                 </div>
 
                 {{-- Responsible Person --}}
@@ -115,6 +118,7 @@
                             <flux:input type="email" wire:model="responsible" />
                             {{-- <flux:input.group.suffix>@domain.com</flux:input.group.suffix> --}}
                         </flux:input.group>
+                        <flux:error name="responsible" />
                     </flux:field>
                 </div>
 
@@ -126,6 +130,7 @@
                             <flux:select.option>{{ $label }}</flux:select.option>
                         @endforeach
                     </flux:select>
+                    <flux:error name="org" />
                 </div>
 
                 {{-- Organization Mail --}}
@@ -145,10 +150,11 @@
                         <flux:date-picker mode="range" wire:model="dateRange"
                                           :label="__('project.view.details.period')" selectable-header
                                           :placeholder="__('project.view.details.period_placeholder')"
-                                          :invalid="$this->getErrorBag()->hasAny(['date_end'])"
+                                          :invalid="$this->getErrorBag()->has('dateRange')"
                         />
+                        {{-- start and end errors are both mapped onto `dateRange` (see ERROR_FIELDS),
+                             because the picker binds one property for the whole range --}}
                         <flux:error name="dateRange" />
-                        <flux:error name="date_end" />
                     </flux:field>
                 </div>
 
@@ -219,12 +225,17 @@
                         </th>
                     </tr>
                     </thead>
-                    <tbody class="divide-y divide-gray-200 bg-white">
+                    <tbody class="divide-y divide-gray-200 bg-white" wire:sort="sortPosts">
                     @foreach ($posts as $index => $post)
-                        <tr class="hover:bg-gray-50" wire:key="post-{{ $index }}">
-                            {{-- Row Number --}}
+                        <tr class="hover:bg-gray-50" wire:key="post-{{ $index }}" wire:sort:item="{{ $index }}">
+                            {{-- Row Number: doubles as the drag handle for reordering --}}
                             <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6">
-                                {{ $loop->iteration }}.
+                                <button type="button" wire:sort:handle
+                                        class="flex cursor-grab items-center gap-2 text-gray-900 active:cursor-grabbing"
+                                        :aria-label="__('project.view.budget_table.reorder')">
+                                    <x-fas-grip-vertical class="h-4 w-4 fill-gray-400"/>
+                                    {{ $loop->iteration }}.
+                                </button>
                             </td>
 
                             {{-- Post Name --}}
@@ -263,14 +274,20 @@
                                 </td>
                             @endif
 
+                            {{-- Income and expenses are mutually exclusive, so each field locks
+                                 once the other one carries an amount — but only while it is
+                                 itself empty. A row that holds both (legacy data) would
+                                 otherwise lock both fields and could never be corrected. --}}
                             {{-- Income --}}
                             <td class="px-3 py-4 text-sm text-gray-900">
-                                <x-money-input wire:model.live.blur="posts.{{ $index }}.einnahmen" :disabled="!$posts[$index]['ausgaben']->isZero()"/>
+                                <x-money-input wire:model.live.blur="posts.{{ $index }}.einnahmen"
+                                               :disabled="$posts[$index]['einnahmen']->isZero() && !$posts[$index]['ausgaben']->isZero()"/>
                             </td>
 
                             {{-- Expenses --}}
                             <td class="px-3 py-4 text-sm text-gray-900">
-                                <x-money-input wire:model.live.blur="posts.{{ $index }}.ausgaben" :disabled="!$posts[$index]['einnahmen']->isZero()"/>
+                                <x-money-input wire:model.live.blur="posts.{{ $index }}.ausgaben"
+                                               :disabled="$posts[$index]['ausgaben']->isZero() && !$posts[$index]['einnahmen']->isZero()"/>
                             </td>
 
                             {{-- Actions --}}
@@ -341,6 +358,7 @@
                     wire:model="beschreibung"
                     :placeholder="__('project.view.description.placeholder')"
                 />
+                <flux:error name="beschreibung" />
             </div>
         </flux:card>
 
@@ -352,6 +370,11 @@
                     with-progress
                 />
             </flux:file-upload>
+            {{-- per-file errors arrive as `uploads.0` and are mapped onto `newAttachments.0` --}}
+            <flux:error name="newAttachments" />
+            @foreach($newAttachments as $uploadIndex => $upload)
+                <flux:error name="newAttachments.{{ $uploadIndex }}" />
+            @endforeach
             <div class="mt-4 flex flex-col gap-2">
                 <div class="mt-2 flex flex-col gap-2">
                     @foreach($newAttachments as $attachment)

--- a/resources/views/pages/project/⚡edit-project/edit-project.php
+++ b/resources/views/pages/project/⚡edit-project/edit-project.php
@@ -15,6 +15,7 @@ use App\Rules\ContentMatchesExtension;
 use App\Rules\NoEmbeddedMacros;
 use App\States\Project\ProjectState;
 use App\States\Project\Terminated;
+use App\Support\Money\MoneyInput;
 use Cknow\Money\Money;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Auth;
@@ -24,6 +25,7 @@ use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Validation\Rules\File;
+use Illuminate\Validation\ValidationException;
 use Livewire\Attributes\Computed;
 use Livewire\Attributes\Layout;
 use Livewire\Attributes\Locked;
@@ -236,6 +238,42 @@ new #[Layout('layout.app', ['size' => 'lg'])] class extends Component
     }
 
     /**
+     * The money leaves of `posts` are Money objects, but they only survive the round trip
+     * while Livewire sends one update per leaf: as soon as its JS diff consolidates the
+     * update into a parent (which it does when every row changed in one commit, or when
+     * the row count drifted), the payload carries no per-leaf synth metadata and the raw
+     * input strings land in `$this->posts`. Re-cast them before anything reads them —
+     * the view calls `->isZero()` on them and the validator compares Money objects.
+     *
+     * This is a Livewire bug, not a rule of the framework: livewire/livewire#10489
+     * ("Recursively hydrate nested synthesizers during property updates") fixes it
+     * server-side and was still open against the 4.x branch when this was written.
+     * Once we run a Livewire release that carries it, this normalization becomes
+     * redundant and can go — the regression tests guard the behaviour, not this method.
+     *
+     * Checked 2026-08-04 against livewire/livewire v4.3.3 (production ran v4.3.1);
+     * the fix is in no 4.x release yet, and the related client-side mitigation
+     * livewire/livewire#10431 sits on main only and cannot see server-only synths
+     * like our MoneySynth anyway.
+     */
+    public function updated(string $name): void
+    {
+        if (str_starts_with($name, 'posts')) {
+            $this->normalizePostMoney();
+        }
+    }
+
+    private function normalizePostMoney(): void
+    {
+        foreach ($this->posts as $index => $post) {
+            foreach (['einnahmen', 'ausgaben'] as $field) {
+                $money = MoneyInput::parse($post[$field] ?? null);
+                $this->posts[$index][$field] = $money ?? Money::EUR(0);
+            }
+        }
+    }
+
+    /**
      * When the budget plan changes, remap every post's titel into the newly
      * selected plan (e.g. a finance officer moving the project to another plan).
      */
@@ -357,6 +395,31 @@ new #[Layout('layout.app', ['size' => 'lg'])] class extends Component
     }
 
     /**
+     * Move a post row, driven by the drag handle in the Nr. column.
+     *
+     * Livewire's native wire:sort passes the dragged item's key and its new index, so the
+     * blade binds the bare method name. The rows are re-indexed afterwards: the array keys
+     * are what the view binds its inputs to, so they have to describe the new order, and
+     * the resulting order is what saveAs() writes to the `position` column.
+     */
+    public function sortPosts(string $key, int $position): void
+    {
+        $from = (int) $key;
+
+        if (! isset($this->posts[$from])) {
+            return;
+        }
+
+        $rows = $this->posts;
+        $moved = $rows[$from];
+        unset($rows[$from]);
+        $rows = array_values($rows);
+        array_splice($rows, $position, 0, [$moved]);
+
+        $this->posts = $rows;
+    }
+
+    /**
      * Remove a post by index
      */
     public function removePost(int $index): void
@@ -371,6 +434,8 @@ new #[Layout('layout.app', ['size' => 'lg'])] class extends Component
      */
     public function saveAs($stateName)
     {
+        // Guards the save against money leaves that never went through updated() (see there).
+        $this->normalizePostMoney();
         try { // rollback on failure
             // check if user is allowed to save
             if ($this->isNew) {
@@ -448,7 +513,11 @@ new #[Layout('layout.app', ['size' => 'lg'])] class extends Component
                 $project->state->transitionTo($state);
             }
 
+            // The row order in the form is the order the user dragged the posts into, and
+            // Project::posts() reads them back ordered by `position`.
+            $position = 0;
             foreach ($filteredPosts as $post) {
+                $post['position'] = $position++;
                 if (isset($post['id'])) {
                     $project->posts()->findOrFail($post['id'])->update($post);
                 } else {
@@ -514,12 +583,67 @@ new #[Layout('layout.app', ['size' => 'lg'])] class extends Component
             DB::commit();
 
             return to_route('project.show', $project->id);
+        } catch (ValidationException $e) {
+            // Validation runs before the transaction opens, so there is nothing to roll back.
+            $this->reportValidationErrors($e);
         } catch (Exception $e) {
             if (DB::transactionLevel() > 0) {
                 DB::rollBack();
             }
             $this->addError('save', 'Fehler beim Speichern: '.$e->getMessage());
         }
+    }
+
+    /**
+     * Validator data key => livewire property whose `flux:error` renders it.
+     *
+     * getValues() renames a few fields on their way into the validator, because the state
+     * rules and the legacy columns speak a different vocabulary than the form does. Errors
+     * come back under the data key, so they need translating back or they land on a name no
+     * input is bound to and stay invisible. Everything absent from this map already matches
+     * on both sides — including every `posts.*` key, which is where most errors occur.
+     */
+    private const array ERROR_FIELDS = [
+        'date_start' => 'dateRange',
+        'date_end' => 'dateRange',
+        'uploads' => 'newAttachments',
+        'deletedAttachments' => 'deletedAttachmentIds',
+    ];
+
+    /**
+     * Put a failed validation onto the individual fields instead of collapsing it into one
+     * line: ValidationException::getMessage() is only ever the *first* message, so catching
+     * it together with real save failures used to drop every other error on the floor.
+     */
+    private function reportValidationErrors(ValidationException $e): void
+    {
+        foreach ($e->errors() as $key => $messages) {
+            foreach ($messages as $message) {
+                $this->addError($this->errorField($key), $message);
+            }
+        }
+
+        // The form is long enough that the offending field is easily off-screen, so the
+        // banner stays — as a pointer to the marked fields rather than a truncated message.
+        $this->addError('save', __('project.error.check-marked-fields'));
+    }
+
+    /**
+     * Translate one validator key (`date_start`, `uploads.0`) into the property that
+     * displays it (`dateRange`, `newAttachments.0`), keeping any index suffix.
+     */
+    private function errorField(string $key): string
+    {
+        foreach (self::ERROR_FIELDS as $dataKey => $property) {
+            if ($key === $dataKey) {
+                return $property;
+            }
+            if (str_starts_with($key, $dataKey.'.')) {
+                return $property.substr($key, strlen($dataKey));
+            }
+        }
+
+        return $key;
     }
 
     /**

--- a/tests/Pest/Project/EditProjectTest.php
+++ b/tests/Pest/Project/EditProjectTest.php
@@ -191,6 +191,49 @@ it('keeps money post fields as Money after string wire:model updates', function 
     expect($component->get('posts.1.einnahmen'))->toBeInstanceOf(Money::class);
 });
 
+/**
+ * Regression guard for the production "Call to a member function getAmount() on string".
+ *
+ * Livewire's JS diff consolidates an update into the parent when every child changed
+ * (touching a field in every post row does that, which is why it only ever showed up on
+ * projects with several posts). The consolidated payload carries no per-leaf synth
+ * metadata, so MoneySynth never runs and the raw input strings land in $posts — the
+ * view then calls ->isZero() on a string and the validator ->getAmount().
+ */
+it('survives a consolidated posts update carrying raw money strings', function (): void {
+    $project = Project::factory()->by(user())->create([
+        'name' => 'Consolidated Update',
+        'responsible' => 'test@open-administration.de',
+    ]);
+    foreach (['First Post', 'Second Post'] as $name) {
+        $project->posts()->create([
+            'name' => $name,
+            'einnahmen' => Money::EUR(0),
+            'ausgaben' => Money::EUR(5000),
+            'bemerkung' => 'This is a description that is long enough for validation.',
+        ]);
+    }
+
+    $component = Livewire::test('pages::project.edit-project', ['project_id' => $project->id]);
+
+    // What the browser sends once the diff consolidates: the whole array, money as strings.
+    $component->set('posts', collect($component->get('posts'))->map(fn (array $post): array => [
+        ...$post,
+        'einnahmen' => '0,00 €',
+        'ausgaben' => '1.234,50 €',
+    ])->all())->assertOk();
+
+    expect($component->get('posts.0.ausgaben'))->toBeInstanceOf(Money::class)
+        ->and($component->get('posts.1.einnahmen'))->toBeInstanceOf(Money::class);
+
+    $component->call('saveAs', 'draft')->assertHasNoErrors();
+
+    // The amounts must survive verbatim: parsing the display string elsewhere (the
+    // MoneyCast, under a non-German locale) would read "1.234,50" as 1.23 EUR.
+    expect($project->refresh()->posts->pluck('ausgaben')->map->getAmount()->all())
+        ->toBe(['123450', '123450']);
+});
+
 it('can add and remove posts', function (): void {
     Livewire::test('pages::project.edit-project')
         ->assertCount('posts', 1)
@@ -198,6 +241,85 @@ it('can add and remove posts', function (): void {
         ->assertCount('posts', 2)
         ->call('removePost', 1)
         ->assertCount('posts', 1);
+});
+
+it('reorders posts by drag and persists the order', function (): void {
+    $project = Project::factory()->by(user())->create([
+        'name' => 'Sortable Project',
+        'responsible' => 'test@open-administration.de',
+    ]);
+    foreach (['First', 'Second', 'Third'] as $name) {
+        $project->posts()->create([
+            'name' => $name,
+            'einnahmen' => Money::EUR(0),
+            'ausgaben' => Money::EUR(5000),
+            'bemerkung' => 'This is a description that is long enough for validation.',
+        ]);
+    }
+
+    $component = Livewire::test('pages::project.edit-project', ['project_id' => $project->id]);
+
+    // wire:sort hands over the dragged row's key and the index it was dropped at.
+    $component->call('sortPosts', '2', 0)->assertOk();
+
+    expect(collect($component->get('posts'))->pluck('name')->all())
+        ->toBe(['Third', 'First', 'Second']);
+
+    $component->call('saveAs', 'draft')->assertHasNoErrors();
+
+    // Project::posts() orders by `position`, so a reload must keep the dragged order.
+    expect($project->refresh()->posts->pluck('name')->all())
+        ->toBe(['Third', 'First', 'Second']);
+});
+
+it('ignores a sort for a row that is no longer there', function (): void {
+    Livewire::test('pages::project.edit-project')
+        ->assertCount('posts', 1)
+        ->call('sortPosts', '7', 0)
+        ->assertOk()
+        ->assertCount('posts', 1);
+});
+
+/**
+ * Regression guard for validation errors being collapsed into a single banner.
+ *
+ * saveAs() caught ValidationException together with real save failures and reported
+ * `$e->getMessage()`, which is only ever the *first* message — every other field error
+ * was dropped. Errors must land on the field that caused them, under the property name
+ * the view binds (getValues() renames some of them on the way into the validator).
+ */
+it('reports validation errors on the fields that caused them', function (): void {
+    $project = Project::factory()->by(user())->create(['name' => 'Invalid Project']);
+    $project->posts()->create([
+        'name' => 'Existing Post',
+        'einnahmen' => Money::EUR(0),
+        'ausgaben' => Money::EUR(5000),
+        'bemerkung' => 'This is a description that is long enough for validation.',
+    ]);
+
+    Livewire::test('pages::project.edit-project', ['project_id' => $project->id])
+        ->set('name', '')
+        ->set('org', '')
+        // both dates missing: the picker binds `dateRange`, the rules key `date_start`/`date_end`
+        ->set('dateRange', ['start' => null, 'end' => null])
+        ->set('posts.0.name', '')
+        ->call('saveAs', 'wip')
+        // every failing field is marked, not just the first one
+        ->assertHasErrors(['name', 'org', 'dateRange', 'posts.0.name'])
+        // and the banner still points at them
+        ->assertHasErrors('save');
+});
+
+it('reports an upload error on the upload field, not under its validator key', function (): void {
+    Storage::fake('projects');
+    // .txt is not in ProjectAttachment::allowedExtensions(), so the extension gate rejects it.
+    $file = UploadedFile::fake()->createWithContent('notes.txt', 'plain text');
+
+    Livewire::test('pages::project.edit-project')
+        ->set('newAttachments', [$file])
+        ->call('saveAs', 'draft')
+        // the rules key is `uploads.0`; the form binds `newAttachments`
+        ->assertHasErrors('newAttachments.0');
 });
 
 it('prevents saving if version has changed (optimistic locking)', function (): void {

--- a/tests/Pest/Support/MoneyTest.php
+++ b/tests/Pest/Support/MoneyTest.php
@@ -1,8 +1,10 @@
 <?php
 
 use App\Rules\ExactlyOneZeroMoneyRule;
+use App\Rules\NonNegativeMoneyRule;
 use App\Support\Money\DefaultMoneyFormater;
 use Cknow\Money\Money as CknowMoney;
+use Illuminate\Support\Facades\Validator;
 use Money\Currency;
 use Money\Money;
 
@@ -38,7 +40,7 @@ it('round-trips format and inverse', function (): void {
  * Runs the rule for `posts.0.einnahmen` against a sibling `posts.*.ausgaben`
  * field and reports whether validation failed.
  */
-function oneZeroRuleFails(CknowMoney $einnahmen, CknowMoney $ausgaben): bool
+function oneZeroRuleFails(mixed $einnahmen, mixed $ausgaben): bool
 {
     $rule = new ExactlyOneZeroMoneyRule('posts.*.ausgaben');
     $rule->setData(['posts' => [0 => ['einnahmen' => $einnahmen, 'ausgaben' => $ausgaben]]]);
@@ -51,6 +53,24 @@ function oneZeroRuleFails(CknowMoney $einnahmen, CknowMoney $ausgaben): bool
     return $failed;
 }
 
+/**
+ * Validates a whole posts array the way the project form does, and returns the message
+ * for one row's field. Goes through a real Validator on purpose: both money rules leave
+ * the `:position` placeholder in their message for the validator to fill from the row
+ * index, so only this path shows what the user actually reads.
+ *
+ * @param  array<int, array{einnahmen: mixed, ausgaben: mixed}>  $posts
+ */
+function postsMoneyMessage(array $posts, string $attribute): ?string
+{
+    $validator = Validator::make(['posts' => $posts], [
+        'posts.*.einnahmen' => [new NonNegativeMoneyRule],
+        'posts.*.ausgaben' => [new NonNegativeMoneyRule, new ExactlyOneZeroMoneyRule('posts.*.einnahmen')],
+    ]);
+
+    return $validator->errors()->first($attribute) ?: null;
+}
+
 it('passes when exactly one of the paired money fields is zero', function (): void {
     expect(oneZeroRuleFails(CknowMoney::EUR(0), CknowMoney::EUR(10000)))->toBeFalse()
         ->and(oneZeroRuleFails(CknowMoney::EUR(5000), CknowMoney::EUR(0)))->toBeFalse();
@@ -59,4 +79,69 @@ it('passes when exactly one of the paired money fields is zero', function (): vo
 it('fails when both fields are zero or both are non-zero', function (): void {
     expect(oneZeroRuleFails(CknowMoney::EUR(0), CknowMoney::EUR(0)))->toBeTrue()
         ->and(oneZeroRuleFails(CknowMoney::EUR(5000), CknowMoney::EUR(10000)))->toBeTrue();
+});
+
+/**
+ * Regression guard for the production "Call to a member function getAmount() on string":
+ * a consolidated Livewire update delivers the money leaves as their raw input strings,
+ * and the rule used to call Money methods on them straight away.
+ */
+it('judges raw money input strings instead of erroring on them', function (): void {
+    expect(oneZeroRuleFails('0,00 €', '100,00 €'))->toBeFalse()
+        ->and(oneZeroRuleFails('50,00 €', CknowMoney::EUR(0)))->toBeFalse()
+        ->and(oneZeroRuleFails('50,00 €', '100,00 €'))->toBeTrue()
+        ->and(oneZeroRuleFails('', '0,00 €'))->toBeTrue();
+});
+
+it('leaves values that are no money at all to the money rule', function (): void {
+    // null (missing/typed-away input) must neither error nor add a second message.
+    expect(oneZeroRuleFails(null, CknowMoney::EUR(0)))->toBeFalse();
+});
+
+it('names the offending row in both money messages', function (): void {
+    // Neither message is much use without the row: the budget table can hold a dozen
+    // Posten and the errors are reported for the whole form at once.
+    $posts = [
+        0 => ['einnahmen' => CknowMoney::EUR(0), 'ausgaben' => CknowMoney::EUR(5000)],
+        1 => ['einnahmen' => CknowMoney::EUR(5000), 'ausgaben' => CknowMoney::EUR(10000)],
+        2 => ['einnahmen' => CknowMoney::EUR(0), 'ausgaben' => CknowMoney::EUR(-5000)],
+    ];
+
+    expect(postsMoneyMessage($posts, 'posts.0.ausgaben'))->toBeNull()
+        ->and(postsMoneyMessage($posts, 'posts.1.ausgaben'))->toContain('Posten 2')
+        ->and(postsMoneyMessage($posts, 'posts.2.ausgaben'))->toContain('Posten 3');
+});
+
+// ── NonNegativeMoneyRule ─────────────────────────────────────────────────────
+
+/**
+ * Runs the rule directly against a single value and reports whether it failed.
+ */
+function nonNegativeRuleFails(mixed $value): bool
+{
+    $rule = new NonNegativeMoneyRule;
+
+    $failed = false;
+    $rule->validate('posts.0.ausgaben', $value, function () use (&$failed): void {
+        $failed = true;
+    });
+
+    return $failed;
+}
+
+it('fails a negative amount', function (): void {
+    // "-50 €" used to pass every rule and silently flip a Posten's expense into income.
+    expect(nonNegativeRuleFails(CknowMoney::EUR(-5000)))->toBeTrue()
+        ->and(nonNegativeRuleFails('-50,00 €'))->toBeTrue();
+});
+
+it('passes positive and zero amounts', function (): void {
+    expect(nonNegativeRuleFails(CknowMoney::EUR(5000)))->toBeFalse()
+        ->and(nonNegativeRuleFails(CknowMoney::EUR(0)))->toBeFalse();
+});
+
+it('leaves a value that is no money at all to the money rule', function (): void {
+    // Skipped, not failed — the `money:EUR` rule on the same field already reports this case,
+    // and failing here too would just add a second, redundant message.
+    expect(nonNegativeRuleFails(null))->toBeFalse();
 });


### PR DESCRIPTION
Hotfix off `main` (v4.4.2, the version running in production) for a production report: saving a project failed with `Call to a member function getAmount() on string`.

## Root cause

Livewire 4's JS diff consolidates an update into the parent whenever every child changed — touching a field in every post row does exactly that. A consolidated payload carries no per-leaf synth metadata, so `MoneySynth` never runs and the raw display strings (`"1.234,50 €"`) land in `$posts`, where the view calls `->isZero()` and the validator `->getAmount()` on them.

This is a known Livewire defect, not a rule of the framework: [livewire/livewire#10489](https://github.com/livewire/livewire/pull/10489) fixes it server-side and was still open against `4.x`; the client-side mitigation [#10431](https://github.com/livewire/livewire/pull/10431) is on `main` only and cannot see server-only synths like ours. A plain `array` of `Carbon` instances degrades identically on 4.x — it is not specific to our money synth. The workaround is documented and dated in `edit-project.php`, with the note that it can be removed once we run a Livewire release carrying the fix.

Only one project with a single post row never triggers it, which is why this sat unnoticed and was reported by exactly one user.

## Also in this release

While the form was open, four adjacent problems in the same flow:

* **Validation errors were collapsed into one banner.** `ValidationException` was caught together with real save failures and only `getMessage()` — the *first* message — survived, so every `flux:error` slot in the form was dead markup. Errors are now reported per field, translated back from the validator's data keys (`date_start`, `uploads.0`) to the properties the form binds (`dateRange`, `newAttachments.0`).
* **A post with both an income and an expense could never be saved.** Each amount field disabled when the *other* was non-zero, so such a row (legacy data) locked both fields while validation rejected precisely that combination. A field now locks only while it is itself empty.
* **Negative amounts** passed every rule and silently inverted the project totals.
* **Post ordering** by drag handle in the Nr. column, persisted to the existing `position` column that `Project::posts()` already sorts by.

Both money messages now name the offending Posten via `:position`, which the validator fills in — matching how the other rules in `app/Rules` phrase theirs.

## Verification

Full suite 266 passed / 12 todos / 0 failures, `composer fix` clean, PHPStan "No errors". New regression guards cover the consolidated payload (asserting amounts persist as `123450`, which also guards the locale-dependent misparse the string path could have caused), the field-level error mapping, the upload-key mapping, and sorting + persistence. The drag handle was checked in a browser.

## Before deploying

Two data checks — both new rules can reject pre-existing rows:

```sql
SELECT COUNT(*) FROM projektposten WHERE einnahmen <> 0 AND ausgaben <> 0;
SELECT COUNT(*) FROM projektposten WHERE einnahmen < 0 OR ausgaben < 0;
```

Rows in the first are now correctable again. Rows in the second would block a save from `wip` onwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)