### PR TITLE
Release 4.4.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "openadministration/stufis",
     "type": "project",
     "description": "Webinterface für das Management und Digitalisierung von Finanzanträgen und deren Buchung für Studierendenschaften nach Deutschem Recht",
-    "version": "4.4.4",
+    "version": "4.4.5",
     "license": "AGPL",
     "require": {
         "php": "^8.4",

--- a/database/migrations/2026_08_11_130000_point_konto_credentials_at_fints_institutes.php
+++ b/database/migrations/2026_08_11_130000_point_konto_credentials_at_fints_institutes.php
@@ -19,20 +19,31 @@ return new class extends Migration
      */
     public function up(): void
     {
+        // Instances upgraded from v3 carry the legacy tables in whatever collation their
+        // server defaulted to back then (utf8mb4_general_ci), while Laravel creates new ones
+        // in the collation from config/database.php (utf8mb4_unicode_ci). InnoDB refuses a
+        // foreign key whose two columns disagree on collation, so this one is pinned to
+        // whatever the column it points at actually uses instead of inheriting the table's.
+        $collation = $this->columnCollation('fints_institutes', 'blz');
+
         // Guarded because MariaDB cannot roll back DDL: if a later step here fails, the
         // migration is not recorded and has to survive being run again.
         if (! Schema::hasColumn('konto_credentials', 'blz')) {
-            Schema::table('konto_credentials', function (Blueprint $table) {
-                $table->char('blz', 8)->nullable()->after('id');
+            Schema::table('konto_credentials', function (Blueprint $table) use ($collation) {
+                $table->char('blz', 8)->collation($collation)->nullable()->after('id');
             });
         }
 
         // Carry the existing accesses over before konto_bank goes away. konto_bank.blz is an
-        // INT, so 8-digit-pad it into the char column the institute list uses.
-        foreach (DB::table('konto_bank')->pluck('blz', 'id') as $bankId => $blz) {
-            DB::table('konto_credentials')
-                ->where('bank_id', $bankId)
-                ->update(['blz' => str_pad((string) $blz, 8, '0', STR_PAD_LEFT)]);
+        // INT, so 8-digit-pad it into the char column the institute list uses. Skipped when
+        // a previous run already got past the point where bank_id is dropped - the values
+        // are in blz by then, and the column this reads is gone.
+        if (Schema::hasColumn('konto_credentials', 'bank_id')) {
+            foreach (DB::table('konto_bank')->pluck('blz', 'id') as $bankId => $blz) {
+                DB::table('konto_credentials')
+                    ->where('bank_id', $bankId)
+                    ->update(['blz' => str_pad((string) $blz, 8, '0', STR_PAD_LEFT)]);
+            }
         }
 
         $orphaned = DB::table('konto_credentials')->whereNull('blz')->count();
@@ -49,7 +60,8 @@ return new class extends Migration
         // replaces these rows with authoritative data.
         $seededAt = DB::table('konto_credentials')->exists() ? Date::now() : null;
 
-        foreach (DB::table('konto_bank')->get() as $bank) {
+        // konto_bank is dropped in the very last statement, so it is still here on a re-run.
+        foreach (Schema::hasTable('konto_bank') ? DB::table('konto_bank')->get() : [] as $bank) {
             $blz = str_pad((string) $bank->blz, 8, '0', STR_PAD_LEFT);
 
             $stillInUse = DB::table('konto_credentials')->where('blz', $blz)->exists();
@@ -73,18 +85,34 @@ return new class extends Migration
         // table prefix, but a database restored from an older dump may carry a different one.
         $foreignKey = $this->foreignKeyOn('konto_credentials', 'bank_id');
 
-        Schema::table('konto_credentials', function (Blueprint $table) use ($foreignKey) {
+        Schema::table('konto_credentials', function (Blueprint $table) use ($collation, $foreignKey) {
             if ($foreignKey !== null) {
                 $table->dropForeign($foreignKey);
             }
             if (Schema::hasColumn('konto_credentials', 'bank_id')) {
                 $table->dropColumn('bank_id');
             }
-            $table->char('blz', 8)->nullable(false)->change();
+            // Also re-stated on an instance where the column already existed: a run that got
+            // as far as the foreign key before failing left it in the legacy collation.
+            $table->char('blz', 8)->collation($collation)->nullable(false)->change();
             $table->foreign('blz')->references('blz')->on('fints_institutes');
         });
 
         Schema::dropIfExists('konto_bank');
+    }
+
+    /**
+     * Collation of the given column, or null when it is not a string column.
+     */
+    private function columnCollation(string $table, string $column): ?string
+    {
+        $row = DB::selectOne(
+            'SELECT COLLATION_NAME FROM information_schema.COLUMNS
+             WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ? AND COLUMN_NAME = ?',
+            [DB::connection()->getTablePrefix().$table, $column],
+        );
+
+        return $row->COLLATION_NAME ?? null;
     }
 
     /**

--- a/docs/feature-changelog.md
+++ b/docs/feature-changelog.md
@@ -1,3 +1,9 @@
+# v4.4.5
+**Betrieb der Instanz:**
+* Das Update auf 4.4.4 brach auf Instanzen, die von Version 3 hochgezogen wurden, mit einem Datenbankfehler ab. Das Update läuft nun auch dort durch und setzt bei einem abgebrochenen Versuch an der Stelle auf, an der es stehengeblieben ist - eine Reparatur der Datenbank von Hand ist nicht nötig.
+
+---
+
 # v4.4.4
 **FinTS Bankimport:**
 * Das Absenden der Formulare auf den Seiten des Bankzugangs führte zu einer Fehlerseite. Betroffen waren das Anlegen eines Zugangs, die Auswahl des TAN-Verfahrens und jede TAN-Eingabe. 

--- a/tests/Pest/Framework/ForeignKeyCollationTest.php
+++ b/tests/Pest/Framework/ForeignKeyCollationTest.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * Instanzen, die von v3 hochgezogen wurden, führen ihre Legacy-Tabellen in
+ * utf8mb4_general_ci, während Laravel neue Tabellen in der Kollation aus
+ * config/database.php anlegt. InnoDB verweigert einen Fremdschlüssel, dessen
+ * beide Spalten sich in der Kollation unterscheiden (errno 150), siehe OP#650.
+ */
+it('has no foreign key spanning two collations', function (): void {
+    $mismatched = DB::select(
+        'SELECT k.TABLE_NAME, k.COLUMN_NAME, c.COLLATION_NAME AS child,
+                k.REFERENCED_TABLE_NAME, p.COLLATION_NAME AS parent
+           FROM information_schema.KEY_COLUMN_USAGE k
+           JOIN information_schema.COLUMNS c
+             ON c.TABLE_SCHEMA = k.TABLE_SCHEMA AND c.TABLE_NAME = k.TABLE_NAME
+            AND c.COLUMN_NAME = k.COLUMN_NAME
+           JOIN information_schema.COLUMNS p
+             ON p.TABLE_SCHEMA = k.TABLE_SCHEMA AND p.TABLE_NAME = k.REFERENCED_TABLE_NAME
+            AND p.COLUMN_NAME = k.REFERENCED_COLUMN_NAME
+          WHERE k.TABLE_SCHEMA = DATABASE()
+            AND k.REFERENCED_TABLE_NAME IS NOT NULL
+            AND c.COLLATION_NAME IS NOT NULL
+            AND c.COLLATION_NAME <> p.COLLATION_NAME'
+    );
+
+    $describe = fn ($row) => "$row->TABLE_NAME.$row->COLUMN_NAME ($row->child) -> ".
+        "$row->REFERENCED_TABLE_NAME.$row->REFERENCED_COLUMN_NAME ($row->parent)";
+
+    expect(array_map($describe, $mismatched))->toBe([]);
+});
+
+it('points bank accesses at the institute list', function (): void {
+    expect(Schema::hasColumn('konto_credentials', 'blz'))->toBeTrue()
+        ->and(Schema::hasTable('konto_bank'))->toBeFalse();
+
+    $columns = collect(DB::select(
+        "SELECT TABLE_NAME, COLLATION_NAME FROM information_schema.COLUMNS
+          WHERE TABLE_SCHEMA = DATABASE() AND COLUMN_NAME = 'blz'
+            AND TABLE_NAME IN (?, ?)",
+        [DB::getTablePrefix().'konto_credentials', DB::getTablePrefix().'fints_institutes'],
+    ))->pluck('COLLATION_NAME', 'TABLE_NAME');
+
+    expect($columns)->toHaveCount(2)
+        ->and($columns->unique())->toHaveCount(1);
+});


### PR DESCRIPTION
Behebt den Abbruch des Updates auf 4.4.4 auf Instanzen, die von Version 3 hochgezogen wurden (OP#650).

## Was war kaputt

```
2026_08_11_130000_point_konto_credentials_at_fints_institutes ... FAIL
SQLSTATE[HY000]: General error: 1005 Can't create table `live__konto_credentials`
(errno: 150 "Foreign key constraint is incorrectly formed")
```

Hochgezogene Instanzen führen ihre Legacy-Tabellen in `utf8mb4_general_ci`, Laravel legt neue Tabellen in der Kollation aus `config/database.php` an (`utf8mb4_unicode_ci`). `konto_credentials.blz` erbte die Kollation ihrer Tabelle, `fints_institutes.blz` die der neuen — und InnoDB verweigert einen Fremdschlüssel, dessen Spalten sich in der Kollation unterscheiden. Typ und Engine stimmten überein, nur die Kollation nicht. Auf der Produktivinstanz: 18 Tabellen `general_ci`, 9 `unicode_ci`. Eine frisch angelegte Datenbank ist durchgängig `unicode_ci` — deshalb hat es weder lokal noch in CI geschlagen.

## Was drin ist

* **Kollation der Kindspalte an die Elternspalte gepinnt**, zur Laufzeit aus `information_schema` gelesen statt hart notiert, damit es auf jeder Instanz passt — beim Anlegen der Spalte und beim `change()` vor dem Fremdschlüssel.
* **Wiederanlauf repariert.** MariaDB kann DDL nicht zurückrollen: der gescheiterte Lauf hatte `bank_id` bereits gelöscht, die Migration aber nicht vermerkt. Ein erneutes `migrate` lief in die Übernahmeschleife und starb an `Unknown column 'bank_id'` — die Instanz wäre auch mit korrigiertem Fremdschlüssel nicht wieder hochgekommen. Übernahmeschleife und `konto_bank`-Zugriffe sind jetzt abgesichert.
* **Test** über das Schema: kein Fremdschlüssel darf zwei Kollationen überspannen.

## Verifikation

Der Split wurde auf der Testdatenbank nachgestellt (Legacy-Tabellen auf `general_ci`, Bankzugang angelegt):

1. bisheriger Stand → reproduziert `errno 150` wortgleich
2. auf dem daraus entstandenen halb migrierten Stand — identisch zur betroffenen Instanz — läuft die korrigierte Migration durch
3. Ergebnis: beide `blz`-Spalten `utf8mb4_unicode_ci`, Fremdschlüssel vorhanden, Zugang übernommen, Institut aus `konto_bank` übernommen, `konto_bank` entfernt
4. `migrate:fresh --seed` weiterhin sauber

Volle Suite grün (408 passed, 12 todos), PHPStan, Rector und `translations:check` ohne Befund.

Die betroffene Instanz braucht **keine Handreparatur** — die Migration setzt dort auf, wo sie stehengeblieben ist.

## Nicht in diesem PR

Die instanzweite Vereinheitlichung der Kollationen ist als **OP#649** für 4.5.0 erfasst. Wichtig dort: `ALTER TABLE ... CONVERT TO CHARACTER SET` wandelt BLOB in TEXT um, und `filedata.data` ist ein LONGBLOB mit den hochgeladenen Belegen — das übliche Einzeiler-Rezept würde sie zerstören.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
