### PR TITLE
Release 4.4.6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /node_modules
+/legacy/runtime
 /public/hot
 /public/build
 /public/storage

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "openadministration/stufis",
     "type": "project",
     "description": "Webinterface für das Management und Digitalisierung von Finanzanträgen und deren Buchung für Studierendenschaften nach Deutschem Recht",
-    "version": "4.4.5",
+    "version": "4.4.6",
     "license": "AGPL",
     "require": {
         "php": "^8.4",

--- a/database/migrations/2026_08_11_130000_point_konto_credentials_at_fints_institutes.php
+++ b/database/migrations/2026_08_11_130000_point_konto_credentials_at_fints_institutes.php
@@ -82,11 +82,14 @@ return new class extends Migration
         }
 
         // The legacy migration hardcoded the name "dev__konto_credentials_ibfk_2" whatever the
-        // table prefix, but a database restored from an older dump may carry a different one.
-        $foreignKey = $this->foreignKeyOn('konto_credentials', 'bank_id');
+        // table prefix, but a database restored from an older dump may carry a different one -
+        // or several: a schema that has been dumped and restored across changes can accumulate
+        // more than one foreign key on the same column. They share an index, so dropping only
+        // one leaves that index alive and the column cannot be dropped (errno 1553).
+        $foreignKeys = $this->foreignKeysOn('konto_credentials', 'bank_id');
 
-        Schema::table('konto_credentials', function (Blueprint $table) use ($collation, $foreignKey) {
-            if ($foreignKey !== null) {
+        Schema::table('konto_credentials', function (Blueprint $table) use ($collation, $foreignKeys) {
+            foreach ($foreignKeys as $foreignKey) {
                 $table->dropForeign($foreignKey);
             }
             if (Schema::hasColumn('konto_credentials', 'bank_id')) {
@@ -116,19 +119,21 @@ return new class extends Migration
     }
 
     /**
-     * Name of the foreign key on the given column, or null when there is none.
+     * Names of every foreign key on the given column.
+     *
+     * @return list<string>
      */
-    private function foreignKeyOn(string $table, string $column): ?string
+    private function foreignKeysOn(string $table, string $column): array
     {
         // Raw, because the query builder would prefix "information_schema.…" as a table name.
-        $row = DB::selectOne(
+        $rows = DB::select(
             'SELECT CONSTRAINT_NAME FROM information_schema.KEY_COLUMN_USAGE
              WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ? AND COLUMN_NAME = ?
                AND REFERENCED_TABLE_NAME IS NOT NULL',
             [DB::connection()->getTablePrefix().$table, $column],
         );
 
-        return $row->CONSTRAINT_NAME ?? null;
+        return array_map(static fn (object $row): string => $row->CONSTRAINT_NAME, $rows);
     }
 
     /**

--- a/docs/feature-changelog.md
+++ b/docs/feature-changelog.md
@@ -1,4 +1,6 @@
-# v4.4.5
+
+
+# v4.4.5 & 4.4.6
 **Betrieb der Instanz:**
 * Das Update auf 4.4.4 brach auf Instanzen, die von Version 3 hochgezogen wurden, mit einem Datenbankfehler ab. Das Update läuft nun auch dort durch und setzt bei einem abgebrochenen Versuch an der Stelle auf, an der es stehengeblieben ist - eine Reparatur der Datenbank von Hand ist nicht nötig.
 

--- a/public/.htaccess
+++ b/public/.htaccess
@@ -18,6 +18,13 @@
     RewriteCond %{REQUEST_URI} (.+)/$
     RewriteRule ^ %1 [L,R=301]
 
+    # Never serve a file whose name starts with a dash. Nothing in the application
+    # is named that way; such a file is a stray, usually PHP's error log landing
+    # in the document root because the active php.ini carries a numeric
+    # `error_log` (a `-1` meant for `error_reporting`). Serving it would hand out
+    # SQL, file paths and internal error messages.
+    RewriteRule (^|/)- - [F,L]
+
     # Send Requests To Front Controller...
     RewriteCond %{REQUEST_FILENAME} !-d
     RewriteCond %{REQUEST_FILENAME} !-f


### PR DESCRIPTION
Zweiter Anlauf für die FinTS-Migration, nachdem eine weitere Instanz an anderer Stelle abgebrochen ist (OP#651), plus zwei Kleinigkeiten, die deployte Checkouts als verändert erscheinen lassen.

## Abbruch mit errno 1553

```
2026_08_11_130000_point_konto_credentials_at_fints_institutes ... FAIL
SQLSTATE[HY000]: General error: 1553 Cannot drop index 'dev__konto_credentials_ibfk_2':
needed in a foreign key constraint
SQL: alter table `live__konto_credentials` drop `bank_id`
```

Kein Folgefehler von OP#650 — diese Instanz hatte den Kollations-Abbruch nie. Die Migration ermittelte den Fremdschlüssel auf `bank_id` mit `selectOne`, also genau einen. Eine mehrfach gesicherte und wieder eingespielte Datenbank kann aber mehrere Fremdschlüssel auf derselben Spalte tragen; sie teilen sich den Index der Spalte, und der verbliebene hält ihn am Leben. Es werden nun alle gelöscht.

## Verifikation

Auf der Testdatenbank nachgestellt, indem ein zweiter Fremdschlüssel auf `bank_id` angelegt wurde:

1. bisheriger Stand → `errno 1553` reproduziert
2. korrigierter Stand → läuft durch, und zwar auf dem halb migrierten Stand, den der Abbruch hinterlässt
3. kombinierter Härtefall — Legacy-Kollation **und** doppelter Fremdschlüssel **und** vorhandene Daten → korrekter Endzustand: beide `blz`-Spalten `utf8mb4_unicode_ci`, Fremdschlüssel auf `fints_institutes` vorhanden, Zugang und Institut übernommen, `konto_bank` entfernt, Fremdschlüssel auf `owner_id` unangetastet

Volle Suite grün (408 passed), PHPStan, Rector und `translations:check` ohne Befund.

## Zwei Aufräumarbeiten am Checkout

* **`legacy/runtime/`** wird zur Laufzeit angelegt (Protokolle von FinTS und der PDF-Erzeugung) und ist jetzt in `.gitignore`.
* **`public/-1`**: Die Datei stammt nicht aus der Anwendung — sie entsteht, wenn in der aktiven `php.ini` bei `error_log` eine Zahl steht (eine `-1`, die für `error_reporting` gedacht war). Sie ist bewusst **nicht** in `.gitignore`: sie gehört gelöscht und die `php.ini` korrigiert. Da die Rewrite-Regel nur auf `index.php` umleitet, wenn der Pfad *keine* vorhandene Datei ist, hat Apache sie direkt ausgeliefert — mitsamt SQL, Dateipfaden und internen Fehlermeldungen. Dateien, deren Name mit einem Bindestrich beginnt, werden nun abgewiesen (`.well-known` und andere Punktdateien sind nicht betroffen).

**Auf den Instanzen zu tun:** `public/-1` löschen und prüfen, ob sie über die Domain erreichbar war.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
